### PR TITLE
Match firmware name casing with manifest

### DIFF
--- a/src/esp32-wifiimprov/esp32-wifiimprov.ino
+++ b/src/esp32-wifiimprov/esp32-wifiimprov.ino
@@ -180,7 +180,7 @@ bool onCommandCallback(improv::ImprovCommand cmd) {
     {
       std::vector<std::string> infos = {
         // Firmware name
-        "ImprovWifiDemo",
+        "ImprovWiFiDemo",
         // Firmware version
         "1.0.0",
         // Hardware chip/variant


### PR DESCRIPTION
ESP Web Tools uses case-sensitive match to match up the firmware name between the manifest and what is returned from Improv.

Manifest has capitalized F in WiFi: https://github.com/jnthas/improv-wifi-demo/blob/main/firmware/manifest.json